### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cognitive-ecosystem.yml
+++ b/.github/workflows/cognitive-ecosystem.yml
@@ -1,5 +1,9 @@
 name: 'Cognitive Ecosystem: Issue Generation Meta-Framework'
 
+permissions:
+  contents: read
+  issues: write
+
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/OzCog/ocguix/security/code-scanning/1](https://github.com/OzCog/ocguix/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it appears that it needs read access to repository contents and write access to issues (to create issues). Therefore, we will set `contents: read` and `issues: write` in the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
