### PR TITLE
Fix container workspace hardcoded paths issue

### DIFF
--- a/demo-cognitive-flowchart.sh
+++ b/demo-cognitive-flowchart.sh
@@ -13,6 +13,7 @@ echo ""
 
 # Create temp directory for demo
 DEMO_DIR="/tmp/cognitive-flowchart-demo"
+rm -rf "$DEMO_DIR"  # Clean up any previous runs
 mkdir -p "$DEMO_DIR"
 cd "$DEMO_DIR"
 
@@ -20,7 +21,9 @@ echo "📁 Demo directory: $DEMO_DIR"
 echo ""
 
 # Copy cognitive agents to demo directory
-cp /home/runner/work/ocguix/ocguix/*.scm .
+# Use the directory where this script is located, not hardcoded paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp "$SCRIPT_DIR"/*.scm . 2>/dev/null || true
 
 echo "🧠 Node 1: Registry Source Discovery Agent"
 echo "===========================================" 
@@ -33,7 +36,7 @@ if [ -f "registry-sources.scm" ]; then
     echo "📡 Executing registry discovery agent..."
     
     # Run the test version to generate real artifacts
-    /home/runner/work/ocguix/ocguix/test-cognitive-flowchart.sh >/dev/null 2>&1 
+    "$SCRIPT_DIR"/test-cognitive-flowchart.sh >/dev/null 2>&1 
     
     # Copy the generated registry listing
     if [ -f "/tmp/cognitive-flowchart-test/registry_listing.json" ]; then

--- a/test-cognitive-flowchart.sh
+++ b/test-cognitive-flowchart.sh
@@ -9,6 +9,7 @@ echo "============================================="
 
 # Create test directory
 TEST_DIR="/tmp/cognitive-flowchart-test"
+rm -rf "$TEST_DIR"  # Clean up any previous runs
 mkdir -p "$TEST_DIR"
 cd "$TEST_DIR"
 
@@ -16,8 +17,10 @@ echo "📁 Test directory: $TEST_DIR"
 echo ""
 
 # Copy source files to test directory
-cp /home/runner/work/ocguix/ocguix/*.scm .
-cp /home/runner/work/ocguix/ocguix/demo-cognitive-flowchart.sh .
+# Use the directory where this script is located, not hardcoded paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp "$SCRIPT_DIR"/*.scm . 2>/dev/null || true
+cp "$SCRIPT_DIR"/demo-cognitive-flowchart.sh . 2>/dev/null || true
 
 echo "🔍 Step 1: Simulating Registry Discovery Agent"
 echo "----------------------------------------------"

--- a/test-distributed-network-integration.sh
+++ b/test-distributed-network-integration.sh
@@ -13,6 +13,7 @@ echo ""
 
 # Create test directory
 TEST_DIR="/tmp/distributed-network-test"
+rm -rf "$TEST_DIR"  # Clean up any previous runs
 mkdir -p "$TEST_DIR"
 cd "$TEST_DIR"
 
@@ -21,10 +22,12 @@ echo ""
 
 # Copy all necessary files
 echo "📋 Copying network components..."
-cp /home/runner/work/ocguix/ocguix/distributed-network-coordinator.scm .
-cp /home/runner/work/ocguix/ocguix/network-communication-protocol.scm .
-cp /home/runner/work/ocguix/ocguix/cognitive-grammar-integration-agent.scm .
-cp /home/runner/work/ocguix/ocguix/*.scm .
+# Use the directory where this script is located, not hardcoded paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp "$SCRIPT_DIR"/distributed-network-coordinator.scm . 2>/dev/null || true
+cp "$SCRIPT_DIR"/network-communication-protocol.scm . 2>/dev/null || true
+cp "$SCRIPT_DIR"/cognitive-grammar-integration-agent.scm . 2>/dev/null || true
+cp "$SCRIPT_DIR"/*.scm . 2>/dev/null || true
 
 echo "✅ Network components copied"
 echo ""

--- a/test-enhanced-discovery-fallback.sh
+++ b/test-enhanced-discovery-fallback.sh
@@ -8,6 +8,7 @@ echo ""
 
 # Create test directory
 TEST_DIR="/tmp/enhanced-discovery-test"
+rm -rf "$TEST_DIR"  # Clean up any previous runs
 mkdir -p "$TEST_DIR"
 cd "$TEST_DIR"
 
@@ -15,8 +16,10 @@ echo "📁 Test directory: $TEST_DIR"
 echo ""
 
 # Copy the enhanced registry discovery agent
-cp /home/runner/work/ocguix/ocguix/registry-discovery-agent.scm .
-cp /home/runner/work/ocguix/ocguix/registry-sources.scm .
+# Use the directory where this script is located, not hardcoded paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cp "$SCRIPT_DIR"/registry-discovery-agent.scm . 2>/dev/null || true
+cp "$SCRIPT_DIR"/registry-sources.scm . 2>/dev/null || true
 
 echo "🔍 Testing Enhanced Package Discovery Capabilities"
 echo "--------------------------------------------------"


### PR DESCRIPTION
This pull request improves the maintainability and flexibility of several scripts by replacing hardcoded paths with dynamically determined script directory paths and adding cleanup steps to ensure fresh test environments. Below is a summary of the most important changes:

### Path Handling Improvements:
* Updated `demo-cognitive-flowchart.sh` to dynamically determine the script's directory (`$SCRIPT_DIR`) and use it for file copying instead of hardcoded paths. [[1]](diffhunk://#diff-7f2f20e702470e56ae222ac4da194b6d95177384b457ad363222349d26c77f34R16-R26) [[2]](diffhunk://#diff-7f2f20e702470e56ae222ac4da194b6d95177384b457ad363222349d26c77f34L36-R39)
* Modified `test-cognitive-flowchart.sh` to use `$SCRIPT_DIR` for copying source files and the demo script, replacing hardcoded paths.
* Adjusted `test-distributed-network-integration.sh` to use `$SCRIPT_DIR` for copying network component files, avoiding hardcoded paths.
* Updated `test-enhanced-discovery-fallback.sh` to use `$SCRIPT_DIR` for copying registry discovery agent files.

### Environment Cleanup Enhancements:
* Added `rm -rf` commands to clean up existing directories (`$DEMO_DIR`, `$TEST_DIR`) before creating new ones in `demo-cognitive-flowchart.sh`, `test-cognitive-flowchart.sh`, `test-distributed-network-integration.sh`, and `test-enhanced-discovery-fallback.sh`. [[1]](diffhunk://#diff-7f2f20e702470e56ae222ac4da194b6d95177384b457ad363222349d26c77f34R16-R26) [[2]](diffhunk://#diff-558d8db602b39185e2b145ea8e29c28dbf05a407390d64b1011e6adabc44c9c2R12-R23) [[3]](diffhunk://#diff-3ccd6ef41d007d8fd181c31cd4e40935349243f85d8e85db1bcb7142de3fc0c5R16) [[4]](diffhunk://#diff-852d431a3410f5f55c7e30979c5e320178b14a3f33e8cc3f9b35f5c9b8ceb237R11-R22)